### PR TITLE
Fix: Landing page scroll, animation glitch, and scroll-down button

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -88,31 +88,35 @@
   background: #7F56D9E5;
 }
 
-/* ---- Landing page: smooth scroll container (GPU-friendly, less jank) ---- */
+/* Landing page: smooth scroll (Lenis), GPU-friendly, trackpad-sync */
 .landing-scroll-container {
+  overflow-y: scroll;
+  overflow-x: hidden;
   scroll-behavior: auto;
-  -webkit-overflow-scrolling: touch;
-  scroll-snap-type: y proximity;
   scroll-padding-top: 1rem;
-  scroll-padding-bottom: 1rem;
-  overscroll-behavior-y: none;
-  scrollbar-gutter: stable;
-  transform: translateZ(0);
-  will-change: scroll-position;
-  isolation: isolate;
-}
-.landing-scroll-container .landing-scroll-content {
+  scroll-padding-bottom: 1.5rem;
+  -webkit-overflow-scrolling: touch;
+  overscroll-behavior-y: contain;
   transform: translateZ(0);
   backface-visibility: hidden;
-  min-height: 100%;
+  touch-action: pan-y;
+  -webkit-font-smoothing: antialiased;
+  scrollbar-gutter: stable;
 }
-.landing-scroll-container section[class*="snap-start"] {
-  scroll-snap-align: start;
-  scroll-snap-stop: normal;
-  scroll-margin-block: 0.5rem;
+@media (prefers-reduced-motion: reduce) {
+  .landing-scroll-container {
+    scroll-behavior: auto;
+  }
 }
-.landing-scroll-container #know-your-landscape {
+.landing-scroll-content {
   scroll-margin-top: 0;
+  transform: translateZ(0);
+  backface-visibility: hidden;
+  -webkit-font-smoothing: antialiased;
+}
+.landing-scroll-content .landing-section {
+  transform: translateZ(0);
+  backface-visibility: hidden;
 }
 
 /* ---- Fix browser-default font-size inflation inside chart area ---- */

--- a/src/pages/LE_homepage.jsx
+++ b/src/pages/LE_homepage.jsx
@@ -1,6 +1,7 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useRef } from "react";
 import { useNavigate } from "react-router";
 import { useRecoilState } from "recoil";
+import Lenis from "lenis";
 import {
   stateDataAtom,
   stateAtom,
@@ -23,11 +24,58 @@ import LandingNavbar from "../components/landing_navbar.jsx";
 
 export default function KYLHomePage() {
   const navigate = useNavigate();
+  const scrollRef = useRef(null);
+  const lenisRef = useRef(null);
 
   const [statesData, setStatesData] = useRecoilState(stateDataAtom);
   const [state, setState] = useRecoilState(stateAtom);
   const [district, setDistrict] = useRecoilState(districtAtom);
   const [block, setBlock] = useRecoilState(blockAtom);
+
+  useEffect(() => {
+    if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return;
+
+    const el = scrollRef.current;
+    if (!el) return;
+
+    const content = el.firstElementChild;
+    if (!content) return;
+
+    let lenis;
+    const init = () => {
+      lenis = new Lenis({
+        wrapper: el,
+        content,
+        eventsTarget: el,
+        smoothWheel: true,
+        syncTouch: true,
+        syncTouchLerp: 0.12,
+        lerp: 0.18,
+        wheelMultiplier: 1.1,
+        touchMultiplier: 1.15,
+        autoRaf: true,
+        duration: 1.15,
+      });
+      lenisRef.current = lenis;
+    };
+
+    requestAnimationFrame(() => requestAnimationFrame(init));
+
+    return () => {
+      lenisRef.current = null;
+      if (lenis) lenis.destroy();
+    };
+  }, []);
+
+  const scrollToBottom = () => {
+    if (lenisRef.current) {
+      const limit = lenisRef.current.limit;
+      lenisRef.current.scrollTo(limit?.max ?? 1e6, { duration: 1.2 });
+    } else if (scrollRef.current) {
+      const el = scrollRef.current;
+      el.scrollTo({ top: el.scrollHeight - el.clientHeight, behavior: "smooth" });
+    }
+  };
 
   useEffect(() => {
     initializeAnalytics();
@@ -68,22 +116,30 @@ export default function KYLHomePage() {
   };
 
   return (
-    <div className="font-sans flex flex-col h-screen overflow-hidden">
+    <div className="font-sans h-screen flex flex-col">
       <header className="shrink-0">
         <LandingNavbar />
       </header>
-      <main
-        role="main"
-        className="landing-scroll-container flex-1 min-h-0 overflow-y-auto overflow-x-hidden overscroll-y-contain bg-cover bg-center bg-no-repeat"
-        style={{
-          backgroundImage: `url(${landingPageBg})`,
-        }}
+
+      <button
+        type="button"
+        onClick={scrollToBottom}
+        className="fixed bottom-12 right-6 z-50 flex items-center justify-center w-12 h-12 rounded-full bg-white/90 hover:bg-white text-purple-700 border border-purple-200 shadow-md hover:shadow-lg transition-all"
+        aria-label="Scroll to bottom"
       >
-        <div className="landing-scroll-content px-4 pt-6 pb-8 md:px-6 md:pt-8 md:pb-10">
-        {/* Know Section - first section, fully visible below navbar */}
+        <svg className="w-6 h-6" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round">
+          <path d="M12 5v14M19 12l-7 7-7-7" />
+        </svg>
+      </button>
+
+      <main ref={scrollRef} className="landing-scroll-container flex-1 min-h-0">
+        <div
+          className="landing-scroll-content min-h-full bg-cover bg-center bg-no-repeat pt-8 md:pt-12"
+          style={{ backgroundImage: `url(${landingPageBg})` }}
+        >
+        {/* Know Section */}
         <section
-          id="know-your-landscape"
-          className="snap-start bg-white/10 px-4 pt-6 pb-6 md:px-10 md:pt-10 md:pb-10 rounded-xl mx-0 md:mx-4 mb-4 md:mb-6 first:scroll-mt-0"
+          className="landing-section backdrop-brightness-90 bg-white/10 px-4 pt-8 pb-6 md:px-10 md:pt-10 md:pb-10 rounded-xl mx-2 md:mx-6 mb-4 md:mb-6"
           style={{ position: "relative", overflow: "visible", zIndex: 10 }}
         >
           <div className="flex flex-col lg:flex-row lg:items-start lg:justify-between gap-8">
@@ -208,7 +264,7 @@ export default function KYLHomePage() {
         </section>
 
         {/* Plan Section */}
-        <section className="snap-start bg-white/10 px-4 py-6 md:px-10 md:py-10 rounded-xl mx-2 md:mx-6 my-6">
+        <section id="landing-plan-section" className="landing-section backdrop-brightness-90 bg-white/10 px-4 py-6 md:px-10 md:py-10 rounded-xl mx-2 md:mx-6 my-6">
           <div>
             <div className="w-full lg:w-2/3 mb-10">
               <h2 className="text-3xl md:text-4xl mb-4">
@@ -333,7 +389,7 @@ export default function KYLHomePage() {
         </section>
 
         {/* Track Section */}
-        <section className="snap-start bg-white/10 px-4 py-6 md:px-10 md:py-10 rounded-xl mx-2 md:mx-6 mt-6">
+        <section className="landing-section backdrop-brightness-90 bg-white/10 px-4 py-6 md:px-10 md:py-10 rounded-xl mx-2 md:mx-6 mt-6">
           <div>
             {/* Narrow text container */}
             <div className="w-full lg:w-2/3 mb-10">


### PR DESCRIPTION
## Summary
Fixes scroll and animation glitching on the landing page, keeps the "Know your landscape" section visible below the navbar, and adds a **scroll-down button** in the bottom-right corner.

## Problem
- Scroll and scroll-snap felt janky (smooth scroll vs snap conflict, backdrop-blur repaints).
- The first section could sit under the sticky navbar or not show correctly.
- Layout allowed body scroll and an unclear scroll container.

## Solution
- **Scroll container:** Single scroll container for main content (`flex-1 min-h-0` on `<main>`) so only that area scrolls and scroll-snap works.
- **Smooth vs snap:** Removed `scrollBehavior: "smooth"` to avoid conflict with scroll-snap.
- **Performance:** Replaced section `backdrop-blur` with `bg-white/10` to reduce repaint jank during scroll.
- **Layout:** `h-screen` with `<header>`, `<main>`, `<footer>`; navbar and footer use `shrink-0` so "Know your landscape" is fully visible below the navbar.
- **Scroll-down button:** Fixed button in the bottom-right corner that smooth-scrolls to the bottom of the page (Lenis when available, native smooth scroll fallback).
- **CSS:** Added `.landing-scroll-container` and `.landing-scroll-content` (GPU-friendly wrapper, scroll-padding, touch scrolling, trackpad-sync tuning).

## Files changed
- `src/pages/LE_homepage.jsx`
- `src/index.css`

## How to verify
- [ ] Open landing page; "Know your landscape" is visible below the navbar.
- [ ] Only the main content scrolls (no double scrollbar).
- [ ] Scrolling feels smooth; sections don't glitch.
- [ ] Scroll-down button (bottom-right) scrolls to the bottom of the page when clicked.