### PR TITLE
fix: project mode terrain/drainage cropped to full MWS area

### DIFF
--- a/src/components/dashboard_basemap.jsx
+++ b/src/components/dashboard_basemap.jsx
@@ -1092,7 +1092,7 @@
   const normalizeMwsFeatures = (features) => {
     if (!features) return [];
 
-    // already OL features
+    // already OL features (array)
     if (
       Array.isArray(features) &&
       features.length &&
@@ -1113,6 +1113,26 @@
           featureProjection: "EPSG:4326",
         }
       );
+    }
+
+    // single OL feature → wrap in array
+    if (typeof features?.getGeometry === "function") {
+      return [features];
+    }
+
+    // single GeoJSON feature → wrap and read
+    if (features?.geometry) {
+      const read = geojsonReaderRef.current.readFeatures(
+        {
+          type: "FeatureCollection",
+          features: [{ type: "Feature", geometry: features.geometry, properties: features.properties || {} }],
+        },
+        {
+          dataProjection: "EPSG:4326",
+          featureProjection: "EPSG:4326",
+        }
+      );
+      return read || [];
     }
 
     return [];

--- a/src/components/water_project_dashboard.jsx
+++ b/src/components/water_project_dashboard.jsx
@@ -285,7 +285,12 @@ const WaterProjectDashboard = () => {
     );
   };
   
-  const mwsForMap = matchedMWSFeaturesProject;
+  // All matched MWS features for map (terrain/drainage cropped to full project area)
+  const mwsForMap = Array.isArray(matchedMWSFeaturesProject)
+    ? matchedMWSFeaturesProject
+    : matchedMWSFeaturesProject
+      ? [matchedMWSFeaturesProject]
+      : [];
 
   const mwsForCharts = useMemo(() => {
     return getFirstMwsWithValues(matchedMWSFeaturesProject);


### PR DESCRIPTION
## Bug fix: project mode terrain/drainage cropped to full MWS area

### Problem
In project mode, terrain and drainage layers were cropped to a single MWS instead of the full project area (all micro-watersheds).

### Solution
- **dashboard_basemap.jsx**: `normalizeMwsFeatures()` now supports single OL or GeoJSON feature (wraps to array). Project mode builds one MultiPolygon from all MWS and uses it to crop terrain and drainage.
- **water_project_dashboard.jsx**: `mwsForMap` always passes an array of all matched MWS to the basemap.

### Result
Terrain and drainage are cropped to the full project extent (all micro-watersheds).