### PR TITLE
fix: preserve panchayat_boundaries style

### DIFF
--- a/src/actions/getVectorLayers.js
+++ b/src/actions/getVectorLayers.js
@@ -65,19 +65,19 @@ export default async function getVectorLayers(layer_store, layer_name, setVisibl
 
   if (layer_store === "panchayat_boundaries") {
     wmsLayer.setStyle(PanchayatBoundariesStyle);
-  }
-
-  wmsLayer.setStyle((feature) => {
-    return new Style({
-      stroke: new Stroke({
-        color: "black",
-        width: 1.2,
-      }),
-      fill: new Fill({
-        color: "rgba(0, 0, 255, 0.25)", 
-      }),
+  } else {
+    wmsLayer.setStyle(() => {
+      return new Style({
+        stroke: new Stroke({
+          color: "black",
+          width: 1.2,
+        }),
+        fill: new Fill({
+          color: "rgba(0, 0, 255, 0.25)",
+        }),
+      });
     });
-  });
+  }
   
   return wmsLayer;
 }


### PR DESCRIPTION
## Summary
Fixes a style override bug in `getVectorLayers` where the custom `panchayat_boundaries` style was being immediately replaced by the generic default style.

## Problem
In `src/actions/getVectorLayers.js`, the code first applies:
- `PanchayatBoundariesStyle` when `layer_store === "panchayat_boundaries"`

But right after that, it always applies a generic style:
- black stroke + blue fill

This unconditional second `setStyle(...)` overwrote the panchayat-specific style.

## Fix
Updated style assignment logic to be conditional:
- If `layer_store === "panchayat_boundaries"`, keep `PanchayatBoundariesStyle`.
- Otherwise, apply the generic default style.

## Impact
- Panchayat boundaries now render with their intended visual style.
- Other vector layers continue to use the existing default style.
- Restores expected map readability and layer-specific styling behavior.

## File changed
- `src/actions/getVectorLayers.js`