### PR TITLE
fix: use boolean setActive for drainage getVectorLayers calls

### DIFF
--- a/src/components/dashboard_basemap.jsx
+++ b/src/components/dashboard_basemap.jsx
@@ -1188,7 +1188,7 @@
 
       const [terrainLayer, drainageLayer] = await Promise.all([
         getImageLayer("terrain", terrainKey, true, "Terrain_Style_11_Classes").catch(() => null),
-        getVectorLayers("drainage", drainageKey, true, "drainage").catch(() => null),
+        getVectorLayers("drainage", drainageKey, true, true).catch(() => null),
       ]);
 
       if (terrainLayer) {
@@ -1332,7 +1332,7 @@ if (isTehsil) {
 
   const [terrainLayer, drainageLayer] = await Promise.all([
     getImageLayer("terrain", terrainKey, true, "Terrain_Style_11_Classes").catch(() => null),
-    getVectorLayers("drainage", drainageKey, true, "drainage").catch(() => null),
+    getVectorLayers("drainage", drainageKey, true, true).catch(() => null),
   ]);
 
   // Clip terrain to MultiPolygon


### PR DESCRIPTION
## Summary
`getVectorLayers` expects the 4th parameter to be `setActive` (boolean). The drainage layer calls passed the string `"drainage"` instead of `true`.

## Change
- `dashboard_basemap.jsx`: `getVectorLayers("drainage", drainageKey, true, "drainage")` → `(..., true, true)` in both places.

## Why
Avoids misleading / incorrect API usage; `setActive` is not a layer name string.