### PR TITLE
Restore GeoLibre download route and reuse LULC rasters

### DIFF
--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -1,0 +1,26 @@
+import fs from "fs";
+import path from "path";
+
+describe("application routes", () => {
+  it("keeps /download_layers wired to the GeoLibre implementation", () => {
+    const appSource = fs.readFileSync(path.join(__dirname, "App.jsx"), "utf8");
+    const downloadPageSource = fs.readFileSync(
+      path.join(__dirname, "pages/LandscapeExplorer.jsx"),
+      "utf8"
+    );
+
+    expect(appSource).toContain(
+      '<Route path="/download_layers" element={<LandscapeExplorer />} />'
+    );
+    expect(downloadPageSource).toContain(
+      'import GeoLibreFrame from "../components/geolibre/GeoLibreFrame";'
+    );
+    expect(downloadPageSource).toContain("<GeoLibreFrame");
+    expect(downloadPageSource).not.toContain(
+      'components/landscape-explorer/map/Map.jsx'
+    );
+    expect(downloadPageSource).not.toContain(
+      'components/landscape-explorer/sidebar/RightSidebar.jsx'
+    );
+  });
+});

--- a/src/components/geolibre/GeoLibreFrame.jsx
+++ b/src/components/geolibre/GeoLibreFrame.jsx
@@ -4,6 +4,7 @@ import {
   geoLibreVersionStatus,
   resolveGeoLibreViewer,
 } from "../../config/geolibre.config";
+import GeoLibreLegend from "./GeoLibreLegend";
 
 const MAX_TECHNICAL_LOG_ENTRIES = 40;
 
@@ -66,6 +67,7 @@ const GeoLibreFrame = ({
   preparationMessage,
   preparationError,
   warning,
+  legends,
   onRetry,
   onProjectState,
 }) => {
@@ -310,9 +312,13 @@ const GeoLibreFrame = ({
         />
       )}
 
+      {!userIssue && viewerState === "loaded" && (
+        <GeoLibreLegend legends={legends} />
+      )}
+
       {!userIssue && viewerVersion && (
         <div
-          className="pointer-events-none absolute bottom-8 right-3 rounded-md border border-slate-300 bg-white/95 px-2 py-1 text-[11px] font-medium text-slate-700 shadow-sm"
+          className="pointer-events-none absolute bottom-3 left-3 rounded-md border border-slate-300 bg-white/95 px-2 py-1 text-[11px] font-medium text-slate-700 shadow-sm"
           title={`Loaded from ${viewer.url}`}
           role="status"
         >

--- a/src/components/geolibre/GeoLibreFrame.jsx
+++ b/src/components/geolibre/GeoLibreFrame.jsx
@@ -35,6 +35,32 @@ export const formatGeoLibreLog = (entries) =>
     ),
   ].join("\n");
 
+// Visibility and opacity are live viewer state. They must not cause a full
+// project replacement, because GeoLibre would tear down and recreate native
+// raster sources that are already resident in the map. Keep only fields that
+// describe project structure, data, or styling in the load signature.
+export const geoLibreProjectLoadSignature = (project) =>
+  project
+    ? JSON.stringify({
+        version: project.version,
+        name: project.name,
+        scope: project.metadata?.scope,
+        bbox: project.mapView?.bbox,
+        layers: (project.layers || []).map((layer) => ({
+          id: layer.id,
+          name: layer.name,
+          type: layer.type,
+          source: layer.source,
+          sourcePath: layer.sourcePath,
+          groupId: layer.groupId,
+          style: layer.style,
+          loadState: layer.metadata?.loadState,
+          featureCount:
+            layer.metadata?.featureCount ?? layer.geojson?.features?.length,
+        })),
+      })
+    : "";
+
 const GeoLibreFrame = ({
   project,
   preparationMessage,
@@ -46,7 +72,7 @@ const GeoLibreFrame = ({
   const frameRef = useRef(null);
   const fitTimerRef = useRef(null);
   const fittedScopeRef = useRef("");
-  const sentProjectRef = useRef(null);
+  const sentProjectSignatureRef = useRef("");
   const sequenceRef = useRef(0);
   const technicalLogRef = useRef([]);
   const [viewerState, setViewerState] = useState("loading");
@@ -138,7 +164,7 @@ const GeoLibreFrame = ({
           actualVersion: event.data.version,
         });
         setViewerVersion(String(event.data.version));
-        sentProjectRef.current = null;
+        sentProjectSignatureRef.current = "";
         setViewerIssue("");
         setViewerState("ready");
         setReadyGeneration((generation) => generation + 1);
@@ -181,11 +207,12 @@ const GeoLibreFrame = ({
 
   useEffect(() => {
     const target = frameRef.current?.contentWindow;
+    const projectSignature = geoLibreProjectLoadSignature(project);
     if (
       !target ||
       !project ||
       !["ready", "loaded"].includes(viewerState) ||
-      sentProjectRef.current === project
+      sentProjectSignatureRef.current === projectSignature
     ) {
       return;
     }
@@ -205,7 +232,7 @@ const GeoLibreFrame = ({
       projectName: project.name,
       layerCount: project.layers?.length || 0,
     });
-    sentProjectRef.current = project;
+    sentProjectSignatureRef.current = projectSignature;
     const bounds = project.mapView?.bbox;
     const scope = project.metadata?.scope;
     const scopeKey = scope

--- a/src/components/geolibre/GeoLibreFrame.test.jsx
+++ b/src/components/geolibre/GeoLibreFrame.test.jsx
@@ -139,6 +139,50 @@ describe("GeoLibre iframe bridge", () => {
     ).toHaveLength(1);
   });
 
+  it("keeps an already-loaded raster source when only visibility changes", () => {
+    const rasterProject = {
+      ...project,
+      layers: [
+        {
+          id: "corestack-lulc_level_2_17_18",
+          name: "LULC Level 2 · 2017-2018",
+          type: "raster",
+          source: {
+            type: "raster",
+            tiles: ["https://geoserver.example/wms?year=17_18&style=level_2"],
+          },
+          visible: true,
+          opacity: 1,
+          style: { rasterBrightnessMin: 0, rasterBrightnessMax: 1 },
+        },
+      ],
+    };
+    const { rerender } = render(<GeoLibreFrame project={rasterProject} />);
+    const frame = screen.getByTitle("GeoLibre GIS workspace");
+    const postMessage = jest.spyOn(frame.contentWindow, "postMessage");
+
+    act(() => announceReady(frame));
+    const loadCount = () =>
+      postMessage.mock.calls.filter(([message]) =>
+        message.type === "geolibre:load-project"
+      ).length;
+    expect(loadCount()).toBe(1);
+
+    rerender(
+      <GeoLibreFrame
+        project={{
+          ...rasterProject,
+          layers: rasterProject.layers.map((layer) => ({
+            ...layer,
+            visible: false,
+          })),
+        }}
+      />
+    );
+
+    expect(loadCount()).toBe(1);
+  });
+
   it("forwards viewer state snapshots for toggle-triggered loading", () => {
     const onProjectState = jest.fn();
     render(

--- a/src/components/geolibre/GeoLibreLegend.jsx
+++ b/src/components/geolibre/GeoLibreLegend.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 
 const GeoLibreLegend = ({ legends = [] }) => {
-  const [collapsed, setCollapsed] = useState(true);
+  const [collapsed, setCollapsed] = useState(false);
   const [selectedTitle, setSelectedTitle] = useState("");
   const previousTitlesRef = useRef([]);
 
@@ -10,6 +10,7 @@ const GeoLibreLegend = ({ legends = [] }) => {
     const addedTitle = titles.find(
       (title) => !previousTitlesRef.current.includes(title)
     );
+    if (addedTitle) setCollapsed(false);
     setSelectedTitle((current) =>
       addedTitle || (titles.includes(current) ? current : titles[0] || "")
     );
@@ -22,7 +23,7 @@ const GeoLibreLegend = ({ legends = [] }) => {
     legends.find((legend) => legend.title === selectedTitle) || legends[0];
 
   return (
-    <aside className="absolute bottom-8 right-3 z-20 w-72 max-w-[calc(100%-1.5rem)] rounded-lg border border-slate-200 bg-white/95 text-slate-800 shadow-xl backdrop-blur-sm">
+    <aside className="absolute bottom-10 right-3 z-20 w-72 max-w-[calc(100%-1.5rem)] rounded-lg border border-slate-200 bg-white/95 text-slate-800 shadow-xl backdrop-blur-sm md:right-[22rem]">
       <button
         type="button"
         className="flex w-full items-center justify-between gap-3 px-3 py-2 text-left text-sm font-semibold"

--- a/src/components/geolibre/GeoLibreLegend.jsx
+++ b/src/components/geolibre/GeoLibreLegend.jsx
@@ -1,0 +1,86 @@
+import { useEffect, useRef, useState } from "react";
+
+const GeoLibreLegend = ({ legends = [] }) => {
+  const [collapsed, setCollapsed] = useState(true);
+  const [selectedTitle, setSelectedTitle] = useState("");
+  const previousTitlesRef = useRef([]);
+
+  useEffect(() => {
+    const titles = legends.map((legend) => legend.title);
+    const addedTitle = titles.find(
+      (title) => !previousTitlesRef.current.includes(title)
+    );
+    setSelectedTitle((current) =>
+      addedTitle || (titles.includes(current) ? current : titles[0] || "")
+    );
+    previousTitlesRef.current = titles;
+  }, [legends]);
+
+  if (!legends.length) return null;
+
+  const selected =
+    legends.find((legend) => legend.title === selectedTitle) || legends[0];
+
+  return (
+    <aside className="absolute bottom-8 right-3 z-20 w-72 max-w-[calc(100%-1.5rem)] rounded-lg border border-slate-200 bg-white/95 text-slate-800 shadow-xl backdrop-blur-sm">
+      <button
+        type="button"
+        className="flex w-full items-center justify-between gap-3 px-3 py-2 text-left text-sm font-semibold"
+        aria-expanded={!collapsed}
+        onClick={() => setCollapsed((value) => !value)}
+      >
+        <span>Legend</span>
+        <span aria-hidden="true">{collapsed ? "+" : "−"}</span>
+      </button>
+
+      {!collapsed && (
+        <div className="border-t border-slate-200 px-3 pb-3 pt-2">
+          {legends.length > 1 ? (
+            <label className="block">
+              <span className="sr-only">Visible layer legend</span>
+              <select
+                className="mb-3 w-full rounded-md border border-slate-300 bg-white px-2 py-1.5 text-sm"
+                value={selected.title}
+                onChange={(event) => setSelectedTitle(event.target.value)}
+              >
+                {legends.map((legend) => (
+                  <option key={legend.title} value={legend.title}>
+                    {legend.title}
+                  </option>
+                ))}
+              </select>
+            </label>
+          ) : (
+            <p className="mb-3 text-sm font-medium">{selected.title}</p>
+          )}
+
+          <ul className="max-h-64 space-y-2 overflow-y-auto text-xs">
+            {selected.items.map((item) => (
+              <li key={`${item.label}-${item.color}`} className="flex items-center gap-2">
+                <span
+                  className={
+                    item.shape === "circle"
+                      ? "h-3 w-3 shrink-0 rounded-full"
+                      : item.shape === "line"
+                        ? "h-0.5 w-4 shrink-0"
+                        : "h-3 w-3 shrink-0 rounded-sm"
+                  }
+                  style={{
+                    backgroundColor: item.color,
+                    border: item.strokeColor
+                      ? `1px solid ${item.strokeColor}`
+                      : undefined,
+                  }}
+                  aria-hidden="true"
+                />
+                <span>{item.label}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </aside>
+  );
+};
+
+export default GeoLibreLegend;

--- a/src/components/geolibre/GeoLibreLegend.test.jsx
+++ b/src/components/geolibre/GeoLibreLegend.test.jsx
@@ -15,11 +15,21 @@ describe("GeoLibre legend", () => {
   it("selects the legend for a newly visible LULC style", () => {
     const { rerender } = render(<GeoLibreLegend legends={[level1]} />);
 
-    fireEvent.click(screen.getByRole("button", { name: "Legend" }));
+    expect(
+      screen.getByRole("button", { name: "Legend" }).getAttribute("aria-expanded")
+    ).toBe("true");
     expect(screen.getByText("Built-up")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Legend" }));
+    expect(
+      screen.getByRole("button", { name: "Legend" }).getAttribute("aria-expanded")
+    ).toBe("false");
 
     rerender(<GeoLibreLegend legends={[level1, level2]} />);
 
+    expect(
+      screen.getByRole("button", { name: "Legend" }).getAttribute("aria-expanded")
+    ).toBe("true");
     expect(
       screen.getByRole("combobox", { name: "Visible layer legend" }).value
     ).toBe("LULC Level 2 legend");

--- a/src/components/geolibre/GeoLibreLegend.test.jsx
+++ b/src/components/geolibre/GeoLibreLegend.test.jsx
@@ -1,0 +1,28 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import GeoLibreLegend from "./GeoLibreLegend";
+
+const level1 = {
+  title: "LULC Level 1 legend",
+  items: [{ label: "Built-up", color: "#ff0000", shape: "square" }],
+};
+
+const level2 = {
+  title: "LULC Level 2 legend",
+  items: [{ label: "Crops", color: "#fad36f", shape: "square" }],
+};
+
+describe("GeoLibre legend", () => {
+  it("selects the legend for a newly visible LULC style", () => {
+    const { rerender } = render(<GeoLibreLegend legends={[level1]} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Legend" }));
+    expect(screen.getByText("Built-up")).toBeTruthy();
+
+    rerender(<GeoLibreLegend legends={[level1, level2]} />);
+
+    expect(
+      screen.getByRole("combobox", { name: "Visible layer legend" }).value
+    ).toBe("LULC Level 2 legend");
+    expect(screen.getByText("Crops")).toBeTruthy();
+  });
+});

--- a/src/components/geolibre/README.md
+++ b/src/components/geolibre/README.md
@@ -94,12 +94,16 @@ ordered top-first as:
 6. Land
 7. Agriculture
 8. Restoration
-9. Climate
-10. NREGA
+9. NREGA
 
 The remaining groups are collapsed. Every layer outside the two default
 Demographic entries is toggle-to-load. Each LULC group shows 2024-2025 first
-while retaining every available year back to 2017-2018.
+while retaining every available year back to 2017-2018. The three LULC levels
+are presentation choices over the same Level 3 coverage for each year: GeoLibre
+uses `lulc_level_1_style`, `lulc_level_2_style`, or `lulc_level_3_style` without
+requesting separate Level 1 and Level 2 raster datasets. These cross-workspace
+styles are rendered through GeoServer's global WMS endpoint; downloads continue
+to use the single Level 3 WCS coverage.
 
 The project camera is calculated from the Socio-Economic geometry using a
 padded Web Mercator fit. `mapView.bbox` is also retained in project metadata,
@@ -175,11 +179,11 @@ application.
 | `GeoLibreFrame.jsx` | Iframe bridge, one-time bbox fit, human error states and downloadable bounded technical log |
 | `../../pages/LandscapeExplorer.jsx` | Route-to-project orchestration and fetch-on-first-toggle vector cache; no duplicate map or layer UI |
 
-The current project contains 45 entries: 13 vector entries, 24 LULC year/level
-rasters, and 8 other rasters. Initial startup performs exactly one distinct WFS
-request for the shared Demographic data and no WMS request. Each other vector
-makes its own WFS request only on its first toggle. Hidden rasters make
-no WMS tile request.
+The current project contains 45 entries: 13 vector entries, 24 LULC year/style
+entries backed by 8 Level 3 yearly rasters, and 8 other rasters. Initial startup
+performs exactly one distinct WFS request for the shared Demographic data and no
+WMS request. Each other vector makes its own WFS request only on its first
+toggle. Hidden rasters make no WMS tile request.
 
 ## Error handling
 

--- a/src/components/geolibre/README.md
+++ b/src/components/geolibre/README.md
@@ -121,15 +121,14 @@ attribution. A deployment can replace it with another valid MapLibre style:
 REACT_APP_GEOLIBRE_BASEMAP_STYLE_URL=https://maps.example.org/style.json
 ```
 
-GeoLibre's built-in Components plugin provides one on-map legend control in
-minimized mode by default. Its rendered legend uses the bottom-right map corner.
-The initial project includes the default-visible layers; a lazy vector hydration
-refreshes the selector with the layers visible at that point. Raster-only
-visibility changes stay inside the iframe instead of sending the full project
-back to GeoLibre. This preserves GeoLibre's native raster sources and avoids
-reloading tiles that have already been added to the map. The separate `legend`
-project field retains the complete layer ordering and grouping for GeoLibre's
-Print Layout legend.
+KYL renders one minimized on-map legend control over the bottom-right map corner.
+Its selector is updated directly from GeoLibre state snapshots and contains the
+currently visible layers. A newly enabled layer becomes the selected legend, so
+Level 1, Level 2, and Level 3 LULC styles each immediately show their own class
+palette. This update does not send the full project back to the iframe, preserving
+GeoLibre's native raster sources and avoiding redundant tile reloads. The
+separate `legend` project field retains the complete layer ordering and grouping
+for GeoLibre's Print Layout legend.
 
 ## Version configuration
 

--- a/src/components/geolibre/README.md
+++ b/src/components/geolibre/README.md
@@ -122,12 +122,14 @@ REACT_APP_GEOLIBRE_BASEMAP_STYLE_URL=https://maps.example.org/style.json
 ```
 
 GeoLibre's built-in Components plugin provides one on-map legend control in
-minimized mode by default. Its rendered legend uses the bottom-right map corner,
-and its selector contains only layers that are currently visible. Toggling a
-layer on adds its symbol classes; toggling it off removes them. One selected
-layer's classes are shown at a time, so enabling several layers does not expand
-every palette across the map. The separate `legend` project field retains the
-complete layer ordering and grouping for GeoLibre's Print Layout legend.
+minimized mode by default. Its rendered legend uses the bottom-right map corner.
+The initial project includes the default-visible layers; a lazy vector hydration
+refreshes the selector with the layers visible at that point. Raster-only
+visibility changes stay inside the iframe instead of sending the full project
+back to GeoLibre. This preserves GeoLibre's native raster sources and avoids
+reloading tiles that have already been added to the map. The separate `legend`
+project field retains the complete layer ordering and grouping for GeoLibre's
+Print Layout legend.
 
 ## Version configuration
 

--- a/src/components/geolibre/geolibreProject.js
+++ b/src/components/geolibre/geolibreProject.js
@@ -781,6 +781,11 @@ const mapLegendEntries = (orderedLayers) => {
     : entries;
 };
 
+export const activeGeoLibreLegends = (project) =>
+  project?.layers
+    ? mapLegendEntries(project.layers.filter((layer) => layer.visible))
+    : [];
+
 const legendPluginState = (entries, currentPlugins) => {
   const selected = entries[0];
   const currentComponents =
@@ -794,7 +799,9 @@ const legendPluginState = (entries, currentPlugins) => {
   const legend = selectedEntry
     ? {
         ...currentLegend,
-        visible: true,
+        // KYL renders this state outside the cross-origin iframe so it can be
+        // updated without replacing the project and recreating raster sources.
+        visible: false,
         collapsed: currentLegend?.collapsed ?? true,
         hasLegend: true,
         selectedLegendIndex: selectedIndex,
@@ -852,9 +859,7 @@ const legendStateSignature = (legend) =>
 
 export const syncGeoLibreActiveLegends = (project) => {
   if (!project?.layers) return project;
-  const entries = mapLegendEntries(
-    project.layers.filter((layer) => layer.visible)
-  );
+  const entries = activeGeoLibreLegends(project);
   const plugins = legendPluginState(entries, project.plugins);
   const currentLegend =
     project.plugins?.settings?.["maplibre-gl-components"]?.legend;

--- a/src/components/geolibre/geolibreProject.js
+++ b/src/components/geolibre/geolibreProject.js
@@ -434,7 +434,6 @@ const GROUPS_TOP_FIRST = [
   { id: "land", name: "Land", collapsed: true },
   { id: "agriculture", name: "Agriculture", collapsed: true },
   { id: "restoration", name: "Restoration", collapsed: true },
-  { id: "climate", name: "Climate", collapsed: true },
   { id: "nrega", name: "NREGA", collapsed: true },
 ];
 
@@ -501,7 +500,11 @@ const buildWfsRequest = (baseUrl, layer, layerName) => {
 };
 
 const buildWmsSource = (baseUrl, layer, layerName, bounds) => {
-  const endpoint = `${baseUrl}${layer.workspace}/wms`;
+  // Cross-workspace LULC styles are available through GeoServer's global WMS,
+  // while other catalog layers retain their workspace-scoped endpoints.
+  const endpoint = layer.useGlobalWms
+    ? `${baseUrl}wms`
+    : `${baseUrl}${layer.workspace}/wms`;
   const qualifiedName = `${layer.workspace}:${layerName}`;
   const source = {
     type: "raster",

--- a/src/components/geolibre/geolibreProject.test.js
+++ b/src/components/geolibre/geolibreProject.test.js
@@ -162,11 +162,31 @@ describe("GeoLibre 2.2 project generation", () => {
     expect(latestLulc.source.tiles[0]).toContain(
       "BBOX={bbox-epsg-3857}"
     );
-    expect(latestLulc.source.wmsUrl).toContain("/LULC_level_3/wms");
+    expect(latestLulc.source.wmsUrl).toContain("/geoserver/wms");
     expect(latestLulc.source.url).toContain("request=GetCoverage");
     expect(latestLulc.source.url).toContain(
       "CoverageId=LULC_level_3%3ALULC_24_25_cachar_lakhipur_level_3"
     );
+    const latestLulcStyles = [1, 2, 3].map((level) =>
+      project.layers.find(
+        (layer) => layer.id === `corestack-lulc_level_${level}_24_25`
+      )
+    );
+    expect(latestLulcStyles.map((layer) => layer.source.layers)).toEqual([
+      "LULC_level_3:LULC_24_25_cachar_lakhipur_level_3",
+      "LULC_level_3:LULC_24_25_cachar_lakhipur_level_3",
+      "LULC_level_3:LULC_24_25_cachar_lakhipur_level_3",
+    ]);
+    expect(latestLulcStyles.map((layer) => layer.source.url)).toEqual([
+      latestLulc.source.url,
+      latestLulc.source.url,
+      latestLulc.source.url,
+    ]);
+    expect(latestLulcStyles.map((layer) => layer.source.styles)).toEqual([
+      "lulc_level_1_style",
+      "lulc_level_2_style",
+      "lulc_level_3_style",
+    ]);
     expect(successfulFetch).toHaveBeenCalledTimes(1);
   });
 
@@ -212,7 +232,6 @@ describe("GeoLibre 2.2 project generation", () => {
       "land",
       "agriculture",
       "restoration",
-      "climate",
       "nrega",
     ]);
   });

--- a/src/components/geolibre/geolibreProject.test.js
+++ b/src/components/geolibre/geolibreProject.test.js
@@ -1,4 +1,5 @@
 import {
+  activeGeoLibreLegends,
   buildGeoLibreProject,
   DEFAULT_GEOLIBRE_BASEMAP_STYLE,
   formatGeoServerName,
@@ -236,7 +237,7 @@ describe("GeoLibre 2.2 project generation", () => {
     ]);
   });
 
-  it("starts a minimized legend containing only active default layers", async () => {
+  it("prepares default legend data for the KYL overlay", async () => {
     const project = await buildGeoLibreProject({
       ...location,
       fetchFeatureCollection: successfulFetch,
@@ -248,7 +249,7 @@ describe("GeoLibre 2.2 project generation", () => {
       "maplibre-gl-components"
     );
     expect(legend).toMatchObject({
-      visible: true,
+      visible: false,
       collapsed: true,
       hasLegend: true,
       title: "Socio-Economic Profile legend",
@@ -307,6 +308,43 @@ describe("GeoLibre 2.2 project generation", () => {
       "Administrative Boundaries legend",
       "Terrain legend",
     ]);
+  });
+
+  it("returns a separate active legend for every visible LULC style", async () => {
+    const project = await buildGeoLibreProject({
+      ...location,
+      fetchFeatureCollection: successfulFetch,
+    });
+    const withLulcStyles = {
+      ...project,
+      layers: project.layers.map((layer) =>
+        [
+          "corestack-lulc_level_1_17_18",
+          "corestack-lulc_level_2_17_18",
+          "corestack-lulc_level_3_17_18",
+        ].includes(layer.id)
+          ? { ...layer, visible: true }
+          : layer
+      ),
+    };
+
+    const legends = activeGeoLibreLegends(withLulcStyles);
+    expect(legends.map((legend) => legend.title)).toEqual(
+      expect.arrayContaining([
+        "LULC Level 1 legend",
+        "LULC Level 2 legend",
+        "LULC Level 3 legend",
+      ])
+    );
+    expect(
+      legends.find((legend) => legend.title === "LULC Level 1 legend").items
+    ).toHaveLength(5);
+    expect(
+      legends.find((legend) => legend.title === "LULC Level 2 legend").items
+    ).toHaveLength(2);
+    expect(
+      legends.find((legend) => legend.title === "LULC Level 3 legend").items
+    ).toHaveLength(4);
   });
 
   it("loads only the shared Demographic source during project creation", async () => {

--- a/src/config/geolibreLayers.js
+++ b/src/config/geolibreLayers.js
@@ -3,6 +3,8 @@ const QML_RAW_BASE =
 
 const qmlStyle = (path) => `${QML_RAW_BASE}/${path}`;
 
+const LULC_SOURCE_WORKSPACE = "LULC_level_3";
+
 export const GEOLIBRE_LULC_YEARS = [
   { label: "2017-2018", value: "17_18" },
   { label: "2018-2019", value: "18_19" },
@@ -282,24 +284,24 @@ const LULC_LEVELS = [
     id: "lulc_level_1",
     label: "LULC Level 1",
     domain: "Land",
-    workspace: "LULC_level_1",
-    wmsStyle: "LULC_level_1:lulc_level_1_style",
+    workspace: LULC_SOURCE_WORKSPACE,
+    wmsStyle: "lulc_level_1_style",
     qmlStyleUrl: qmlStyle("Land/level-1-op.qml"),
   },
   {
     id: "lulc_level_2",
     label: "LULC Level 2",
     domain: "Land",
-    workspace: "LULC_level_2",
-    wmsStyle: "LULC_level_2:lulc_level_2_style",
+    workspace: LULC_SOURCE_WORKSPACE,
+    wmsStyle: "lulc_level_2_style",
     qmlStyleUrl: qmlStyle("Land/level-2.qml"),
   },
   {
     id: "lulc_level_3",
     label: "LULC Level 3",
     domain: "Agriculture",
-    workspace: "LULC_level_3",
-    wmsStyle: "LULC_level_3:lulc_level_3_style",
+    workspace: LULC_SOURCE_WORKSPACE,
+    wmsStyle: "lulc_level_3_style",
     qmlStyleUrl: qmlStyle("Agriculture/level-3.qml"),
   },
 ];
@@ -312,9 +314,10 @@ export const GEOLIBRE_LULC_LAYERS = LULC_LEVELS.flatMap((level, index) =>
     label: `${level.label} · ${year.label}`,
     loadGroup: `lulc-${index + 1}`,
     sourceType: "wms",
+    useGlobalWms: true,
     year: year.value,
     layerName: ({ district, tehsil }) =>
-      `LULC_${year.value}_${district}_${tehsil}_level_${index + 1}`,
+      `LULC_${year.value}_${district}_${tehsil}_level_3`,
   }))
 );
 

--- a/src/pages/LandscapeExplorer.jsx
+++ b/src/pages/LandscapeExplorer.jsx
@@ -3,6 +3,7 @@ import { Link, useLocation } from "react-router-dom";
 import { useRecoilValue } from "recoil";
 import GeoLibreFrame from "../components/geolibre/GeoLibreFrame";
 import {
+  activeGeoLibreLegends,
   buildGeoLibreProject,
   hydrateGeoLibreVectorLayer,
   syncGeoLibreActiveLegends,
@@ -52,6 +53,7 @@ const LandscapeExplorer = () => {
   const selectedTehsil = useRecoilValue(blockAtom);
   const routeLocation = useLocation();
   const [project, setProject] = useState(null);
+  const [legends, setLegends] = useState([]);
   const [progress, setProgress] = useState("Starting GeoLibre…");
   const [error, setError] = useState("");
   const [retryKey, setRetryKey] = useState(0);
@@ -84,6 +86,7 @@ const LandscapeExplorer = () => {
     lazyQueueRef.current = Promise.resolve();
     hydratedLayersRef.current = new Map();
     hydrationDirtyRef.current = false;
+    setLegends([]);
   }, [scopeKey]);
 
   useEffect(() => {
@@ -112,6 +115,7 @@ const LandscapeExplorer = () => {
       .then((nextProject) => {
         if (controller.signal.aborted) return;
         setProject(nextProject);
+        setLegends(activeGeoLibreLegends(nextProject));
         setProgress("Overview is ready. Toggle another layer to load it.");
         trackEvent("GeoLibre", "open_workspace", scope.tehsil);
       })
@@ -129,6 +133,9 @@ const LandscapeExplorer = () => {
 
   const handleProjectState = useCallback((viewerProject) => {
     const viewerScopeKey = scopeKeyOf(viewerProject);
+    if (viewerScopeKey === currentScopeKeyRef.current) {
+      setLegends(activeGeoLibreLegends(viewerProject));
+    }
     const sequence = lazyStateSequenceRef.current + 1;
     lazyStateSequenceRef.current = sequence;
 
@@ -221,6 +228,7 @@ const LandscapeExplorer = () => {
         preparationMessage={progress}
         preparationError={error}
         warning={warning}
+        legends={legends}
         onProjectState={handleProjectState}
         onRetry={() => setRetryKey((value) => value + 1)}
       />

--- a/src/pages/LandscapeExplorer.jsx
+++ b/src/pages/LandscapeExplorer.jsx
@@ -1,457 +1,227 @@
-import { useState, useEffect, useRef, useCallback } from "react";
-import Map from "../components/landscape-explorer/map/Map.jsx";
-import RightSidebar from "../components/landscape-explorer/sidebar/RightSidebar.jsx";
-import { useRecoilState } from "recoil";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Link, useLocation } from "react-router-dom";
+import { useRecoilValue } from "recoil";
+import GeoLibreFrame from "../components/geolibre/GeoLibreFrame";
 import {
-  stateDataAtom,
-  stateAtom,
-  districtAtom,
+  buildGeoLibreProject,
+  hydrateGeoLibreVectorLayer,
+  syncGeoLibreActiveLegends,
+} from "../components/geolibre/geolibreProject";
+import LandingNavbar from "../components/landing_navbar";
+import {
   blockAtom,
-  filterSelectionsAtom,
-  yearAtom,
-} from "../store/locationStore.jsx";
-import getStates from "../actions/getStates.js";
-import * as downloadHelper from "../components/landscape-explorer/utils/downloadHelper";
+  districtAtom,
+  stateAtom,
+} from "../store/locationStore";
 import {
-  trackPageView,
-  trackEvent,
   initializeAnalytics,
+  trackEvent,
+  trackPageView,
 } from "../services/analytics";
-import LandingNavbar from "../components/landing_navbar.jsx";
+
+const labelOf = (selection) => selection?.label || "";
+
+const scopeKeyOf = (project) => {
+  const scope = project?.metadata?.scope;
+  return scope ? [scope.state, scope.district, scope.tehsil].join("|") : "";
+};
+
+const mergeHydratedVectorLayers = (viewerProject, hydratedLayers) => ({
+  ...viewerProject,
+  layers: viewerProject.layers.map((layer) => {
+    const hydrated = hydratedLayers.get(layer.id);
+    if (!hydrated) return layer;
+    return {
+      ...layer,
+      geojson: hydrated.geojson,
+      metadata: {
+        ...layer.metadata,
+        ...hydrated.metadata,
+        corestack: {
+          ...layer.metadata?.corestack,
+          ...hydrated.metadata?.corestack,
+        },
+      },
+    };
+  }),
+});
 
 const LandscapeExplorer = () => {
-  const [showLeftSidebar, setShowLeftSidebar] = useState(false);
-  const [showRightSidebar, setShowRightSidebar] = useState(true);
-  const [isLoading, setIsLoading] = useState(false);
+  const selectedState = useRecoilValue(stateAtom);
+  const selectedDistrict = useRecoilValue(districtAtom);
+  const selectedTehsil = useRecoilValue(blockAtom);
+  const routeLocation = useLocation();
+  const [project, setProject] = useState(null);
+  const [progress, setProgress] = useState("Starting GeoLibre…");
+  const [error, setError] = useState("");
+  const [retryKey, setRetryKey] = useState(0);
+  const currentScopeKeyRef = useRef("");
+  const lazyQueueRef = useRef(Promise.resolve());
+  const lazyStateSequenceRef = useRef(0);
+  const hydratedLayersRef = useRef(new Map());
+  const hydrationDirtyRef = useRef(false);
 
-  // Recoil state
-  const [statesData, setStatesData] = useRecoilState(stateDataAtom);
-  const [state, setState] = useRecoilState(stateAtom);
-  const [district, setDistrict] = useRecoilState(districtAtom);
-  const [block, setBlock] = useRecoilState(blockAtom);
-  const [filterSelections, setFilterSelections] =
-    useRecoilState(filterSelectionsAtom);
-  const [lulcYear1, setLulcYear1] = useState(null);
-  const [lulcYear2, setLulcYear2] = useState(null);
-  const [lulcYear3, setLulcYear3] = useState(null);
+  const scope = useMemo(() => {
+    const params = new URLSearchParams(routeLocation.search);
+    return {
+      state: params.get("state") || labelOf(selectedState),
+      district: params.get("district") || labelOf(selectedDistrict),
+      tehsil: params.get("tehsil") || labelOf(selectedTehsil),
+    };
+  }, [
+    routeLocation.search,
+    selectedDistrict,
+    selectedState,
+    selectedTehsil,
+  ]);
 
-  // Map ref for accessing map instance from other components
-  const mapRef = useRef(null);
+  const hasLocation = Boolean(scope.state && scope.district && scope.tehsil);
+  const scopeKey = [scope.state, scope.district, scope.tehsil].join("|");
 
-  // Add flag to prevent infinite recursion
-  const isUpdatingFromMap = useRef(false);
+  useEffect(() => {
+    currentScopeKeyRef.current = scopeKey;
+    lazyStateSequenceRef.current += 1;
+    lazyQueueRef.current = Promise.resolve();
+    hydratedLayersRef.current = new Map();
+    hydrationDirtyRef.current = false;
+  }, [scopeKey]);
 
-  // Track which resource category is active
-  const [activeResourceCategory, setActiveResourceCategory] = useState(null);
-
-  // Set map ref with callback
-  const setMapRef = useCallback((node) => {
-    if (node !== null) {
-      mapRef.current = node;
-    }
-  }, []);
-
-  // Layer toggle state - with demographics on by default
-  const [toggledLayers, setToggledLayers] = useState({
-    // Basic layers
-    demographics: true, // Set to true by default
-    drainage: false,
-    remote_sensed_waterbodies: false,
-    hydrological_boundaries: false,
-    clart: false,
-    mws_layers: false,
-    nrega: false,
-    drought: false,
-    terrain: false,
-    administrative_boundaries: false,
-    cropping_intensity: false,
-    terrain_vector: false,
-    terrain_lulc_slope: false,
-    terrain_lulc_plain: false,
-    afforestation: false,
-    deforestation: false,
-    degradation: false,
-    urbanization: false,
-    cropintensity: false,
-    soge: false,
-    aquifer: false,
-  });
-
-  // State for map view settings
-  const [showMWS, setShowMWS] = useState(true);
-  const [showVillages, setShowVillages] = useState(true);
-
-  // Add plans state
-  const [plans, setPlans] = useState([]);
-
-  // Add internal state flag for when layers are ready
-  const [layersReady, setLayersReady] = useState(false);
-
-  // Flag to track if we need to enable the fetch button
-  const [canFetchLayers, setCanFetchLayers] = useState(block !== null);
-
-  // Handle item selection for dropdowns
-  const handleItemSelect = (setter, value) => {
-    // Handle the setState case specially if it affects parent component state
-    if (setter === setState) {
-      // Reset all dependent state values
-      if (value) {
-        trackEvent("Location", "select_state", value.label);
-      }
-      setDistrict(null);
-      setBlock(null);
-      resetAllStates();
-      setState(value);
-    } else if (setter === setDistrict) {
-      // Reset block and filters when district changes
-      if (value) {
-        trackEvent("Location", "select_district", value.label);
-      }
-      setBlock(null);
-      resetAllStates();
-      setDistrict(value);
-    } else if (setter === setBlock) {
-      resetAllStates();
-      setBlock(value);
-      // When block is selected, enable fetch button and prepare layers automatically
-      setCanFetchLayers(true);
-      trackEvent("Location", "select_tehsil", value.label);
-      // Auto-prepare layers instead of requiring Fetch Layers button
-      setTimeout(() => {
-        if (mapRef.current && mapRef.current.prepareLayers) {
-          setIsLoading(true);
-          mapRef.current.prepareLayers();
-          setLayersReady(true);
-          setToggledLayers((prev) => ({
-            ...prev,
-            demographics: true,
-          }));
-          setIsLoading(false);
-        }
-      }, 100);
-    } else {
-      // Standard case for other setters
-      setter(value);
-    }
-  };
-
-  const resetAllStates = () => {
-    // Reset filters
-    setFilterSelections({
-      selectedMWSValues: {},
-      selectedVillageValues: {},
-    });
-
-    setToggledLayers({
-      demographics: true, // Keep demographics on
-      drainage: false,
-      remote_sensed_waterbodies: false,
-      hydrological_boundaries: false,
-      clart: false,
-      mws_layers: false,
-      nrega: false,
-      drought: false,
-      terrain: false,
-      administrative_boundaries: false,
-      cropping_intensity: false,
-      terrain_vector: false,
-      terrain_lulc_slope: false,
-      terrain_lulc_plain: false,
-      settlement: false,
-      water_structure: false,
-      well_structure: false,
-      agri_structure: false,
-      livelihood_structure: false,
-      recharge_structure: false,
-      afforestation: false,
-      deforestation: false,
-      degradation: false,
-      urbanization: false,
-      cropintensity: false,
-      soge: false,
-      aquifer: false,
-    });
-
-    setLayersReady(false);
-    setCanFetchLayers(false);
-  };
-
-  // Handle layer toggle from RightSidebar
-  const handleLayerToggle = (layerName, isVisible) => {
-    // Prevent recursion if the update is coming from the map component
-    if (isUpdatingFromMap.current) {
-      return;
-    }
-
-    // Update local state immediately
-    setToggledLayers((prev) => ({
-      ...prev,
-      [layerName]: isVisible,
-    }));
-
-    // Then update the map with a slight delay
-    setTimeout(() => {
-      if (mapRef.current && mapRef.current.toggleLayer) {
-        mapRef.current.toggleLayer(layerName, isVisible);
-      }
-    }, 50);
-  };
-
-  // Handle GeoJSON download
-  const handleGeoJsonLayers = (layerName) => {
-    if (!district || !block) {
-      alert("Please select a district and block first");
-      return;
-    }
-
-    console.log(`Downloading GeoJSON for ${layerName}`);
-
-    const districtFormatted = district.label
-      .toLowerCase()
-      .replace(/\s*\(\s*/g, "_")
-      .replace(/\s*\)\s*/g, "")
-      .replace(/\s+/g, "_");
-    const blockFormatted = block.label
-      .toLowerCase()
-      .replace(/\s*\(\s*/g, "_")
-      .replace(/\s*\)\s*/g, "")
-      .replace(/\s+/g, "_");
-
-    // Create download URL based on layer name (following the original implementation's URL format)
-    let downloadUrl = "";
-
-    switch (layerName) {
-      case "demographics":
-        downloadUrl = `https://geoserver.core-stack.org:8443/geoserver/panchayat_boundaries/ows?service=WFS&version=1.0.0&request=GetFeature&typeName=panchayat_boundaries:${districtFormatted}_${blockFormatted}&outputFormat=application/json&screen=main`;
-        break;
-      case "drainage":
-        downloadUrl = `https://geoserver.core-stack.org:8443/geoserver/drainage/ows?service=WFS&version=1.0.0&request=GetFeature&typeName=drainage:${districtFormatted}_${blockFormatted}&outputFormat=application/json&screen=main`;
-        break;
-      case "remote_sensed_waterbodies":
-        downloadUrl = `https://geoserver.core-stack.org:8443/geoserver/swb/ows?service=WFS&version=1.0.0&request=GetFeature&typeName=swb:surface_waterbodies_${districtFormatted}_${blockFormatted}&outputFormat=application/json&screen=main`;
-        break;
-      case "hydrological_boundaries":
-        downloadUrl = `https://geoserver.core-stack.org:8443/geoserver/mws_layers/ows?service=WFS&version=1.0.0&request=GetFeature&typeName=mws_layers:deltaG_well_depth_${districtFormatted}_${blockFormatted}&outputFormat=application/json&screen=main`;
-        break;
-      // Add other cases as needed
-      default:
-        downloadUrl = `https://geoserver.core-stack.org:8443/geoserver/${layerName}/ows?service=WFS&version=1.0.0&request=GetFeature&typeName=${layerName}:${districtFormatted}_${blockFormatted}&outputFormat=application/json&screen=main`;
-    }
-
-    // Use the imported helper directly
-    downloadHelper.downloadGeoJson(downloadUrl, layerName);
-  };
-
-  // Handle KML download
-  const handleKMLLayers = (layerName) => {
-    if (!district || !block) {
-      alert("Please select a district and block first");
-      return;
-    }
-
-    console.log(`Downloading KML for ${layerName}`);
-
-    const districtFormatted = district.label
-      .toLowerCase()
-      .replace(/\s*\(\s*/g, "_")
-      .replace(/\s*\)\s*/g, "")
-      .replace(/\s+/g, "_");
-    const blockFormatted = block.label
-      .toLowerCase()
-      .replace(/\s*\(\s*/g, "_")
-      .replace(/\s*\)\s*/g, "")
-      .replace(/\s+/g, "_");
-
-    // Create download URL based on layer name (following original implementation)
-    let downloadUrl = "";
-
-    switch (layerName) {
-      case "demographics":
-        downloadUrl = `https://geoserver.core-stack.org:8443/geoserver/panchayat_boundaries/ows?service=WFS&version=1.0.0&request=GetFeature&typeName=panchayat_boundaries:${districtFormatted}_${blockFormatted}&outputFormat=application/vnd.google-earth.kml+xml&screen=main`;
-        break;
-      case "drainage":
-        downloadUrl = `https://geoserver.core-stack.org:8443/geoserver/drainage/ows?service=WFS&version=1.0.0&request=GetFeature&typeName=drainage:${districtFormatted}_${blockFormatted}&outputFormat=application/vnd.google-earth.kml+xml&screen=main`;
-        break;
-      case "remote_sensed_waterbodies":
-        downloadUrl = `https://geoserver.core-stack.org:8443/geoserver/water_bodies/ows?service=WFS&version=1.0.0&request=GetFeature&typeName=water_bodies:surface_waterbodies_${districtFormatted}_${blockFormatted}&outputFormat=application/vnd.google-earth.kml+xml&screen=main`;
-        break;
-      case "hydrological_boundaries":
-        downloadUrl = `https://geoserver.core-stack.org:8443/geoserver/mws_layers/ows?service=WFS&version=1.0.0&request=GetFeature&typeName=mws_layers:deltaG_well_depth_${districtFormatted}_${blockFormatted}&outputFormat=application/vnd.google-earth.kml+xml&screen=main`;
-        break;
-      // Add other cases as needed
-      default:
-        downloadUrl = `https://geoserver.core-stack.org:8443/geoserver/${layerName}/ows?service=WFS&version=1.0.0&request=GetFeature&typeName=${layerName}:${districtFormatted}_${blockFormatted}&outputFormat=application/vnd.google-earth.kml+xml&screen=main`;
-    }
-
-    // Use the imported helper directly
-    downloadHelper.downloadKml(downloadUrl, layerName);
-  };
-
-  // Handle Excel download
-  const handleExcelDownload = () => {
-    if (!district || !block) {
-      alert("Please select a district and block first");
-      return;
-    }
-
-    setIsLoading(true);
-
-    // Using the exact URL format from the original implementation
-    fetch(
-      `https://geoserver.core-stack.org/api/v1/download_excel_layer?state=${state.label}&district=${district.label}&block=${block.label}`,
-      {
-        method: "GET",
-        headers: {
-          "ngrok-skip-browser-warning": "1",
-          "Content-Type": "blob",
-        },
-      }
-    )
-      .then((response) => response.arrayBuffer())
-      .then((arybuf) => {
-        const url = window.URL.createObjectURL(new Blob([arybuf]));
-        const link = document.createElement("a");
-
-        link.href = url;
-        link.setAttribute("download", `${block.label}_data.xlsx`);
-        document.body.appendChild(link);
-        link.click();
-
-        link.remove();
-        URL.revokeObjectURL(url);
-        setIsLoading(false);
-      })
-      .catch((error) => {
-        console.error("Error downloading Excel:", error);
-        setIsLoading(false);
-        alert("Failed to download Excel data. Please try again.");
-      });
-  };
-
-  // Track category selection for resource layers
-  const handleCategoryChange = (category) => {
-    setActiveResourceCategory(category);
-  };
-
-  // Fetch states data on component mount
   useEffect(() => {
     initializeAnalytics();
     trackPageView("/download_layers");
-    if (statesData === null) {
-      getStates().then((data) => setStatesData(data));
-    }
-  }, [statesData, setStatesData]);
+  }, []);
 
-  // Handle map-initiated layer toggle updates
-  const handleMapToggle = (layerName, isVisible) => {
-    // Set the recursion prevention flag
-    isUpdatingFromMap.current = true;
+  useEffect(() => {
+    if (!hasLocation) return undefined;
+    const controller = new AbortController();
+    setProject(null);
+    setError("");
+    setProgress(`Loading the Socio-Economic Profile for ${scope.tehsil}…`);
 
-    try {
-      // Special case for setState action - coming from map marker click
-      if (layerName === "setState" && typeof isVisible === "object") {
-        if (isVisible && isVisible.label && isVisible.district) {
-          setState(isVisible);
+    buildGeoLibreProject({
+      ...scope,
+      signal: controller.signal,
+      viewport: {
+        width: Math.max(window.innerWidth - 340, 320),
+        height: Math.max(window.innerHeight - 100, 320),
+      },
+      onProgress: ({ message }) => {
+        if (!controller.signal.aborted) setProgress(message);
+      },
+    })
+      .then((nextProject) => {
+        if (controller.signal.aborted) return;
+        setProject(nextProject);
+        setProgress("Overview is ready. Toggle another layer to load it.");
+        trackEvent("GeoLibre", "open_workspace", scope.tehsil);
+      })
+      .catch((buildError) => {
+        if (controller.signal.aborted) return;
+        setError(
+          buildError instanceof Error
+            ? buildError.message
+            : "The tehsil project could not be generated."
+        );
+      });
+
+    return () => controller.abort();
+  }, [hasLocation, retryKey, scope]);
+
+  const handleProjectState = useCallback((viewerProject) => {
+    const viewerScopeKey = scopeKeyOf(viewerProject);
+    const sequence = lazyStateSequenceRef.current + 1;
+    lazyStateSequenceRef.current = sequence;
+
+    lazyQueueRef.current = lazyQueueRef.current
+      .catch(() => undefined)
+      .then(async () => {
+        if (viewerScopeKey !== currentScopeKeyRef.current) return;
+
+        const mergedProject = mergeHydratedVectorLayers(
+          viewerProject,
+          hydratedLayersRef.current
+        );
+        let nextProject = syncGeoLibreActiveLegends(mergedProject);
+        const legendChanged = nextProject !== mergedProject;
+        const layersToLoad = nextProject.layers.filter(
+          (layer) =>
+            layer.type === "geojson" &&
+            layer.visible &&
+            ["unloaded", "error"].includes(layer.metadata?.loadState)
+        );
+
+        for (const layer of layersToLoad) {
+          nextProject = await hydrateGeoLibreVectorLayer({
+            project: nextProject,
+            layerId: layer.id,
+          });
+          const hydrated = nextProject.layers.find(
+            (item) => item.id === layer.id
+          );
+          if (hydrated) hydratedLayersRef.current.set(layer.id, hydrated);
+          hydrationDirtyRef.current = true;
+        }
+
+        if (
+          viewerScopeKey !== currentScopeKeyRef.current ||
+          sequence !== lazyStateSequenceRef.current ||
+          (!layersToLoad.length &&
+            !hydrationDirtyRef.current &&
+            !legendChanged)
+        ) {
           return;
         }
-      }
 
-      // Update the toggledLayers state
-      setToggledLayers((prev) => ({
-        ...prev,
-        [layerName]: isVisible,
-      }));
-    } finally {
-      // Reset the flag
-      isUpdatingFromMap.current = false;
-    }
-  };
+        hydrationDirtyRef.current = false;
+        setProject(nextProject);
+      });
+  }, []);
+
+  if (!hasLocation) {
+    return (
+      <div className="flex h-screen flex-col bg-slate-100">
+        <LandingNavbar />
+        <main className="flex min-h-0 flex-1 items-center justify-center p-6">
+          <div className="max-w-md rounded-2xl bg-white p-7 text-center shadow-xl">
+            <h1 className="text-xl font-semibold text-slate-900">
+              Select a tehsil first
+            </h1>
+            <p className="mt-2 text-sm leading-6 text-slate-600">
+              GeoLibre projects are generated for a selected state, district,
+              and tehsil.
+            </p>
+            <Link
+              to="/"
+              className="mt-5 inline-flex rounded-lg bg-purple-700 px-4 py-2 text-sm font-semibold text-white hover:bg-purple-800"
+            >
+              Select location
+            </Link>
+          </div>
+        </main>
+      </div>
+    );
+  }
+
+  const failures =
+    project?.metadata?.layerLoading?.initialLoadFailures?.length || 0;
+  const lazyFailures =
+    project?.metadata?.layerLoading?.lazyLoadFailures?.length || 0;
+  const totalFailures = failures + lazyFailures;
+  const warning = totalFailures
+    ? `${totalFailures} layer${totalFailures === 1 ? "" : "s"} could not be loaded. Toggle the layer off and on to retry.`
+    : "";
 
   return (
-    <div className="min-h-screen bg-white flex flex-col">
-      <div className="sticky top-0 z-50 bg-white border-b border-gray-100">
-        <LandingNavbar />
-      </div>
-      <div className="flex h-[calc(100vh-48px)]">
-
-
-        <div className="flex-1 relative p-2">
-
-          <Map
-            ref={setMapRef}
-            isLoading={isLoading}
-            setIsLoading={setIsLoading}
-            state={state}
-            district={district}
-            block={block}
-            filterSelections={filterSelections}
-            toggledLayers={toggledLayers}
-            toggleLayer={handleMapToggle} // Use handleMapToggle to properly handle map-initiated updates
-            showMWS={showMWS}
-            setShowMWS={setShowMWS}
-            showVillages={showVillages}
-            setShowVillages={setShowVillages}
-            lulcYear1={lulcYear1}
-            lulcYear2={lulcYear2}
-            lulcYear3={lulcYear3}
-          />
-        </div>
-
-        {showRightSidebar && (
-          <RightSidebar
-            state={state}
-            district={district}
-            block={block}
-            setState={setState}
-            setDistrict={setDistrict}
-            setBlock={setBlock}
-            statesData={statesData}
-            handleItemSelect={handleItemSelect}
-            onClose={() => setShowRightSidebar(false)}
-            handleLayerToggle={handleLayerToggle}
-            handleGeoJsonLayers={handleGeoJsonLayers}
-            handleKMLLayers={handleKMLLayers}
-            toggledLayers={toggledLayers}
-            toggleLayer={handleLayerToggle}
-            handleExcelDownload={handleExcelDownload}
-            isLoading={isLoading}
-            canFetchLayers={canFetchLayers}
-            onCategoryChange={handleCategoryChange}
-            lulcYear1={lulcYear1}
-            lulcYear2={lulcYear2}
-            lulcYear3={lulcYear3}
-            setLulcYear1={setLulcYear1}
-            setLulcYear2={setLulcYear2}
-            setLulcYear3={setLulcYear3}
-          />
-        )}
-
-        {!showRightSidebar && (
-          <div className="absolute top-20 right-0 z-10 bg-white p-2 px-3 rounded-l-md shadow-md hover:bg-gray-100 transition-colors flex items-center">
-            <button
-              onClick={() => setShowRightSidebar(true)}
-              className="flex items-center"
-              aria-label="Open filters panel"
-            >
-              <span className="font-medium text-gray-700 mr-2">
-                Filters & Data
-              </span>
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                width="16"
-                height="16"
-                fill="currentColor"
-                viewBox="0 0 16 16"
-              >
-                <path
-                  fillRule="evenodd"
-                  d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0z"
-                />
-              </svg>
-            </button>
-          </div>
-        )}
-      </div>
+    <div className="flex h-screen flex-col overflow-hidden bg-white">
+      <LandingNavbar />
+      <GeoLibreFrame
+        project={project}
+        preparationMessage={progress}
+        preparationError={error}
+        warning={warning}
+        onProjectState={handleProjectState}
+        onRetry={() => setRetryKey((value) => value + 1)}
+      />
     </div>
   );
 };

--- a/src/pages/LandscapeExplorer.jsx
+++ b/src/pages/LandscapeExplorer.jsx
@@ -141,8 +141,7 @@ const LandscapeExplorer = () => {
           viewerProject,
           hydratedLayersRef.current
         );
-        let nextProject = syncGeoLibreActiveLegends(mergedProject);
-        const legendChanged = nextProject !== mergedProject;
+        let nextProject = mergedProject;
         const layersToLoad = nextProject.layers.filter(
           (layer) =>
             layer.type === "geojson" &&
@@ -165,13 +164,16 @@ const LandscapeExplorer = () => {
         if (
           viewerScopeKey !== currentScopeKeyRef.current ||
           sequence !== lazyStateSequenceRef.current ||
-          (!layersToLoad.length &&
-            !hydrationDirtyRef.current &&
-            !legendChanged)
+          (!layersToLoad.length && !hydrationDirtyRef.current)
         ) {
           return;
         }
 
+        // A visibility-only state already lives inside the GeoLibre iframe.
+        // Sending it back as a full project would recreate every native raster
+        // source and make an already-loaded WMS layer fetch its tiles again.
+        // Only replace the project when lazy vector hydration supplied new data.
+        nextProject = syncGeoLibreActiveLegends(nextProject);
         hydrationDirtyRef.current = false;
         setProject(nextProject);
       });


### PR DESCRIPTION
## What changed

- restore the GeoLibre-based `LandscapeExplorer` at `/download_layers`
- add a route contract test that rejects the legacy map/sidebar implementation
- remove the empty Climate group from the GeoLibre layer panel
- point all Level 1, Level 2, and Level 3 LULC entries at the same Level 3 coverage for each year
- render that shared coverage with the corresponding Level 1, Level 2, or Level 3 GeoServer style
- stop visibility-only viewer snapshots from reloading the full GeoLibre project
- preserve native raster sources when a loaded LULC layer is toggled off and on
- update the KYL legend directly from GeoLibre state snapshots, without reloading the iframe project
- display the initial legend expanded over the map and automatically reopen/select the palette for each newly visible LULC style
- retain the Level 3 WCS coverage for GeoTIFF downloads and document the shared-source contract

## Why

An earlier revert kept `/download_layers` mapped to `LandscapeExplorer` but replaced that page orchestration with the older OpenLayers map and Filters & Data sidebar. This restores the GeoLibre page that existed immediately before that revert.

The three LULC levels contain identical raster data and differ only in styling. The integration previously reused the Level 3 coverage, but each visibility snapshot was echoed back as a complete project load. That recreated native raster sources and caused already-loaded WMS tiles to be requested again. Simply stopping that reload also stopped the iframe legend plugin from receiving visibility changes, so the legend now follows the same snapshots independently.

The first overlay implementation remained collapsed and sat below GeoLibre’s right-hand style panel. It is now expanded initially, positioned over the map, and reopened whenever a new visible legend is detected.

## Impact

`/download_layers` once again loads the hosted GeoLibre workspace. Users keep the existing per-year Level 1, Level 2, and Level 3 choices, all backed by the canonical Level 3 coverage. Toggling an existing layer off and on no longer replaces the project or recreates its raster source. Each newly displayed LULC level visibly opens its own prepared class palette. A first view of a different level can still request its distinct server-rendered WMS style tiles; it does not load a separate Level 1 or Level 2 raster dataset.

## Validation

- 4 focused suites passed, 20 tests total
- legend regression confirms the initial palette is expanded and a newly visible Level 2 style reopens/selects the Level 2 palette
- shared-source regression confirms visibility-only raster changes do not send another `load-project`
- route regression confirms `/download_layers` points to the GeoLibre page and excludes legacy Map/RightSidebar imports
- focused ESLint and `git diff --check` passed
- production build completed successfully; existing unrelated ESLint warnings remain
- `npm start` compiled successfully and `/download_layers` returned HTTP 200
- headless Chrome loaded the hosted GeoLibre 2.5.0 iframe and visually confirmed the initial legend over the map
- live iframe toggles confirmed 2017–18 Level 2 shows Trees and forests/Crops and Level 1 shows its five prepared classes
- live Level 3 WMS returned valid PNG tiles for all three named LULC styles